### PR TITLE
Message notice

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -29,6 +29,15 @@ li {
   display: block;
 }
 
+.notice-icon {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.has-notice {
+  background-color: red;
+}
+
 //layoutsフォルダ
 //application
 header {

--- a/app/controllers/questions/answers_controller.rb
+++ b/app/controllers/questions/answers_controller.rb
@@ -17,10 +17,11 @@ class Questions::AnswersController < ApplicationController
       if @answer.save
         @reply = ReplyForm.new
         @post = Post.find(@answer.post_id)
+        redirect_to root_path if @post.nil? # @postが見つからない場合の処理
         @answers = @post.answers
-        @post.solved_by_questioner if @post&.user_id == @answer.user_id # 自己解決した場合の処理
+        @post.solved_by_questioner if @post.user_id == @answer.user_id # 自己解決した場合の処理
         answer = Answer.where(user_id: @answer.user_id).last
-        answer.send_notice_to_questioner_or_answerers # 質問に回答した際の通知処理
+        answer&.send_notice_to_questioner_or_answerers # 質問に回答した際の通知処理
         format.html { redirect_to questions_post_path(@answer.post_id) }
         format.js
       else
@@ -38,6 +39,7 @@ class Questions::AnswersController < ApplicationController
     respond_to do |format|
       if @answer.save
         @post = Post.find(answer.post_id)
+        redirect_to root_path if @post.nil? # @postが見つからない場合の処理
         @answers = @post.answers
         format.html { redirect_to questions_post_path(answer.post_id) }
         format.js

--- a/app/controllers/questions/answers_controller.rb
+++ b/app/controllers/questions/answers_controller.rb
@@ -3,6 +3,11 @@
 class Questions::AnswersController < ApplicationController
   before_action :authenticate_user!
 
+  # 回答、リプライした質問を一覧表示
+  def index
+    @comment_lists = QuestionEntry.sorted_comment_entries(current_user)
+  end
+
   # 回答の新規作成
   def create
     @answer = AnswerForm.new

--- a/app/controllers/questions/answers_controller.rb
+++ b/app/controllers/questions/answers_controller.rb
@@ -12,8 +12,9 @@ class Questions::AnswersController < ApplicationController
         @reply = ReplyForm.new
         @post = Post.find(@answer.post_id)
         @answers = @post.answers
-        # 自己解決した場合
-        @post.solved_by_questioner if @post.user_id == @answer.user_id
+        @post.solved_by_questioner if @post.user_id == @answer.user_id # 自己解決した場合の処理
+        answer = Answer.where(user_id: @answer.user_id).last
+        answer.send_notice_to_questioner_or_answerers # 質問に回答した際の通知処理
         format.html { redirect_to questions_post_path(@answer.post_id) }
         format.js
       else

--- a/app/controllers/questions/categories_controller.rb
+++ b/app/controllers/questions/categories_controller.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 class Questions::CategoriesController < ApplicationController
+  before_action :check_category_id
   
   # 1つのカテゴリーに所属する質問を一覧表示する
   def show
     @category = Category.find(params[:id])
     @posts = Post.order(created_at: :desc).where(category_id: @category).page(params[:page])
   end
+
+  private
+
+    # DBに存在しないカテゴリーidを入力した場合はrootにリダイレクトする
+    def check_category_id
+      redirect_to root_path unless Category.exists?(id: params[:id])
+    end
 
 end

--- a/app/controllers/questions/posts_controller.rb
+++ b/app/controllers/questions/posts_controller.rb
@@ -32,6 +32,8 @@ class Questions::PostsController < ApplicationController
     @post_form = PostForm.new
     @post_form.assign_attributes(post_params)
     if @post_form.save
+      post = Post.where(user_id: current_user).last
+      post.create_entry # 質問投稿者用の通知レコードを作成
       redirect_to users_basic_path(current_user), flash: { notice: "質問を投稿しました。" }
     else
       render :new

--- a/app/controllers/questions/posts_controller.rb
+++ b/app/controllers/questions/posts_controller.rb
@@ -70,6 +70,7 @@ class Questions::PostsController < ApplicationController
     @post_form = PostForm.new(post)
     @post_form.assign_attributes(post_params)
     if @post_form.save
+      post.send_notice_to_answerers # 回答者全員に通知を送信する
       redirect_to questions_post_path(post), flash: { notice: "ベストアンサーが決定しました！" }
     else
       render "questions/posts/show"

--- a/app/controllers/questions/posts_controller.rb
+++ b/app/controllers/questions/posts_controller.rb
@@ -34,7 +34,7 @@ class Questions::PostsController < ApplicationController
     @post_form.assign_attributes(post_params)
     if @post_form.save
       post = Post.where(user_id: current_user).last
-      post.create_notice # 質問投稿者用の通知レコードを作成
+      post&.create_notice # 質問投稿者用の通知レコードを作成
       redirect_to users_basic_path(current_user), flash: { notice: "質問を投稿しました。" }
     else
       render :new
@@ -87,7 +87,7 @@ class Questions::PostsController < ApplicationController
     # 新規作成画面のセレクトボックスの初期値を表示
     def set_categories_for_new
       @parent_categories = Category.where(ancestry: nil)
-      @children_categories = @parent_categories.first.children
+      @children_categories = @parent_categories.first&.children
     end
 
     # 編集画面のセレクトボックスの初期値を表示

--- a/app/controllers/questions/posts_controller.rb
+++ b/app/controllers/questions/posts_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Questions::PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :edit, :update]
+  before_action :authenticate_user!, only: [:create, :edit, :update, :select_best_answer]
+  before_action :restricted_editing_post, only: [:edit, :update, :select_best_answer]
   before_action :set_categories_for_new, only: [:new, :create]
   before_action :set_categories_for_edit, only: [:edit, :update]
-  before_action :restricted_editing_post, only: [:edit, :update]
   
   # すべての質問一覧
   def index
@@ -98,7 +98,7 @@ class Questions::PostsController < ApplicationController
 
     # 他人の質問編集画面を閲覧できない、かつ編集できない制限
     def restricted_editing_post
-      redirect_to users_basic_path(current_user) if current_user.posts.exclude?(Post.find(params[:id]))
+      redirect_to users_basic_path(current_user) if current_user.posts.ids.exclude?(params[:id].to_i)
     end
 
 end

--- a/app/controllers/questions/posts_controller.rb
+++ b/app/controllers/questions/posts_controller.rb
@@ -34,7 +34,7 @@ class Questions::PostsController < ApplicationController
     @post_form.assign_attributes(post_params)
     if @post_form.save
       post = Post.where(user_id: current_user).last
-      post.create_entry # 質問投稿者用の通知レコードを作成
+      post.create_notice # 質問投稿者用の通知レコードを作成
       redirect_to users_basic_path(current_user), flash: { notice: "質問を投稿しました。" }
     else
       render :new

--- a/app/controllers/questions/posts_controller.rb
+++ b/app/controllers/questions/posts_controller.rb
@@ -14,6 +14,7 @@ class Questions::PostsController < ApplicationController
   # 各質問の表示画面
   def show
     @post = Post.find(params[:id])
+    @post.remove_notice(current_user) # 投稿詳細画面に入ると通知が外れる処理
     # 回答とそのリプライフォーム用のオブジェクトを定義
     @answer = AnswerForm.new
     @reply = ReplyForm.new

--- a/app/controllers/questions/replies_controller.rb
+++ b/app/controllers/questions/replies_controller.rb
@@ -13,7 +13,7 @@ class Questions::RepliesController < ApplicationController
         @post = @answer.post
         @answers = @post.answers
         reply = Reply.where(user_id: @reply.user_id).last
-        reply.send_notice_to_commenter
+        reply.send_notice_to_commenter # 回答にリプライした際の通知処理
         format.html { redirect_to questions_post_path(@reply.post_id) }
         format.js
       else

--- a/app/controllers/questions/replies_controller.rb
+++ b/app/controllers/questions/replies_controller.rb
@@ -2,6 +2,7 @@
 
 class Questions::RepliesController < ApplicationController
   before_action :authenticate_user!
+  before_action :restricted_editing_reply, only: :update
 
   # リプライの新規作成
   def create
@@ -47,6 +48,11 @@ class Questions::RepliesController < ApplicationController
 
     def reply_params
       params.require(:reply_form).permit(:id, :body, :post_id, :answer_id, pictures_attributes: [:picture]).merge(user_id: current_user.id)
+    end
+
+    # 他人のリプライは編集できないよう制限する
+    def restricted_editing_reply
+      redirect_to users_basic_path(current_user) if current_user.replies.ids.exclude?(params[:id].to_i)
     end
 
 end

--- a/app/controllers/questions/replies_controller.rb
+++ b/app/controllers/questions/replies_controller.rb
@@ -12,6 +12,8 @@ class Questions::RepliesController < ApplicationController
         @answer = Answer.find(@reply.answer_id)
         @post = @answer.post
         @answers = @post.answers
+        reply = Reply.where(user_id: @reply.user_id).last
+        reply.send_notice_to_commenter
         format.html { redirect_to questions_post_path(@reply.post_id) }
         format.js
       else

--- a/app/controllers/questions/replies_controller.rb
+++ b/app/controllers/questions/replies_controller.rb
@@ -11,10 +11,11 @@ class Questions::RepliesController < ApplicationController
     respond_to do |format|
       if @reply.save
         @answer = Answer.find(@reply.answer_id)
+        redirect_to root_path if @answer.nil? # @answerが見つからない場合の処理
         @post = @answer.post
         @answers = @post.answers
         reply = Reply.where(user_id: @reply.user_id).last
-        reply.send_notice_to_commenter # 回答にリプライした際の通知処理
+        reply&.send_notice_to_commenter # 回答にリプライした際の通知処理
         format.html { redirect_to questions_post_path(@reply.post_id) }
         format.js
       else
@@ -34,6 +35,7 @@ class Questions::RepliesController < ApplicationController
     respond_to do |format|
       if @reply.save
         @answer = Answer.find(@reply.answer_id)
+        redirect_to root_path if @answer.nil? # @answerが見つからない場合の処理
         @post = @answer.post
         format.html { redirect_to questions_post_path(@reply.post_id) }
         format.js

--- a/app/controllers/users/basics_controller.rb
+++ b/app/controllers/users/basics_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Users::BasicsController < ApplicationController
-  before_action :authenticate_user!, only: :show
-  before_action :restricted_viewing_deleted_user, only: :show
+  before_action :authenticate_user!
+  before_action :check_user_id
+  before_action :restricted_viewing_deleted_user
   
   def show
     @user = User.find(params[:id])
@@ -17,6 +18,11 @@ class Users::BasicsController < ApplicationController
 end
 
   private
+
+    # DBに存在しないユーザーidを入力した場合はrootにリダイレクトする
+    def check_user_id
+      redirect_to root_path unless User.exists?(id: params[:id])
+    end
 
     # 退会済みのユーザーの画面は表示できないように制限
     def restricted_viewing_deleted_user

--- a/app/controllers/users/basics_controller.rb
+++ b/app/controllers/users/basics_controller.rb
@@ -7,7 +7,7 @@ class Users::BasicsController < ApplicationController
   def show
     @user = User.find(params[:id])
     # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
-    @is_room, @room_id, @entry = current_user.find_or_create_room_for(@user) if current_user != @user
+    @is_room, @room_id, @entry = Entry.find_or_create_partner(current_user, @user) if current_user != @user
     # ユーザーが投稿した質問を降順で表示
     @posts = Post.where(user_id: @user).order(created_at: :desc)
   end

--- a/app/controllers/users/basics_controller.rb
+++ b/app/controllers/users/basics_controller.rb
@@ -6,8 +6,10 @@ class Users::BasicsController < ApplicationController
   
   def show
     @user = User.find(params[:id])
-    # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
-    @is_room, @room_id, @entry = Entry.find_or_create_partner(current_user, @user) if current_user != @user
+    # 共通のメッセージルームを持つ場合はroom_idを返す
+    @room_id = Entry.find_room_id(current_user, @user) if current_user != @user
+    # room_idがない場合はルーム作成フォーム用のインスタンスを生成
+    @entry = Entry.new if @room_id.nil?
     # ユーザーが投稿した質問を降順で表示
     @posts = Post.where(user_id: @user).order(created_at: :desc)
   end

--- a/app/controllers/users/basics_controller.rb
+++ b/app/controllers/users/basics_controller.rb
@@ -6,29 +6,8 @@ class Users::BasicsController < ApplicationController
   
   def show
     @user = User.find(params[:id])
-    # ログインユーザーのすべてのentryを取得
-    @current_entry = Entry.where(user_id: current_user.id)
-    # メッセージ相手のすべてのentryを取得
-    @another_entry = Entry.where(user_id: @user.id)
-    # ログインユーザー以外のユーザーのプロフィール画面を表示した場合
-    unless current_user.id == @user.id
-      # ログインユーザーとメッセージ相手に共通のroomが存在するかどうかを
-      # entryから探し出し、存在の有無を@is_roomというインスタンスで識別する
-      @current_entry.each do |current|
-        @another_entry.each do |another|
-          if current.room_id == another.room_id
-            @is_room = true
-            @room_id = current.room_id
-          end
-        end
-      end
-      # 共通のroomが存在しなかった場合、roomとentryのインスタンスを作成
-      unless @is_room
-        @room = Room.new
-        @entry = Entry.new
-      end
-    end
-
+    # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
+    @is_room, @room_id, @entry = current_user.find_or_create_room_for(@user) if current_user != @user
     # ユーザーが投稿した質問を降順で表示
     @posts = Post.where(user_id: @user).order(created_at: :desc)
   end

--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -7,6 +7,8 @@ class Users::MessagesController < ApplicationController
     @message = MessageForm.new
     @message.assign_attributes(message_form_params)
     if @message.save
+      message = Messasge.where(user_id: current_user).last
+      message.send_notice_to_partner # メッセージ相手に通知を送信する処理
       redirect_to users_room_path(@message.room_id)
     else
       @room = Room.find(@message.room_id)

--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -9,11 +9,12 @@ class Users::MessagesController < ApplicationController
     @message.assign_attributes(message_form_params)
     if @message.save
       message = Message.where(user_id: current_user).last
-      message.send_notice_to_partner # メッセージ相手に通知を送信する処理
+      message&.send_notice_to_partner # メッセージ相手に通知を送信する処理
       redirect_to users_room_path(@message.room_id)
     else
       @room = Room.find(@message.room_id)
       @another_entry = @room.entries.partner_of(current_user)
+      redirect_to root_path if @room.nil? || @another_entry.nil? # roomとentryが見つからなかった場合の処理
       render "users/rooms/show"
     end
   end

--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -7,7 +7,7 @@ class Users::MessagesController < ApplicationController
     @message = MessageForm.new
     @message.assign_attributes(message_form_params)
     if @message.save
-      message = Messasge.where(user_id: current_user).last
+      message = Message.where(user_id: current_user).last
       message.send_notice_to_partner # メッセージ相手に通知を送信する処理
       redirect_to users_room_path(@message.room_id)
     else

--- a/app/controllers/users/rooms_controller.rb
+++ b/app/controllers/users/rooms_controller.rb
@@ -12,7 +12,7 @@ class Users::RoomsController < ApplicationController
     # Entryモデルに相手のレコードを作成
     @another_entry = Entry.create(user_id: entry_params[:user_id], room_id: room.id)
     # 作成した部屋を表示
-    redirect_to users_room_path(room.id)
+    redirect_to users_room_path(room)
   end
 
   def index
@@ -24,9 +24,10 @@ class Users::RoomsController < ApplicationController
 
   def show
     @room = Room.find(params[:id])
-    @room.remove_notice(current_user) # メッセージルームに入ると通知が外れる処理
+    @room&.remove_notice(current_user) # メッセージルームに入ると通知が外れる処理
     @message = MessageForm.new # formのmodelに入れるオブジェクトを作成
     @another_entry = @room.entries.partner_of(current_user) # メッセージ相手と部屋の情報を取得
+    redirect_to root_path if @another_entry.nil? # 相手の情報がなかった場合の処理
   end
 
   private
@@ -37,7 +38,7 @@ class Users::RoomsController < ApplicationController
 
     # 他人のメッセージルームを閲覧できないよう制限
     def restricted_room_viewing
-      current_room_ids = current_user.entries.map { |current_entry| current_entry.room_id}
+      current_room_ids = current_user.entries.map(&:room_id)
       redirect_to users_basic_path(current_user) if current_room_ids.exclude?(params[:id].to_i)
     end
 

--- a/app/controllers/users/rooms_controller.rb
+++ b/app/controllers/users/rooms_controller.rb
@@ -23,12 +23,10 @@ class Users::RoomsController < ApplicationController
   end
 
   def show
-    # メッセージ相手のroom情報をパスから取得し、@roomに代入
     @room = Room.find(params[:id])
-    # formのmodelに入れるオブジェクトを作成
-    @message = MessageForm.new
-    # メッセージ相手と部屋の情報を取得
-    @another_entry = @room.entries.partner_of(current_user)
+    @room.remove_notice(current_user) # メッセージルームに入ると通知が外れる処理
+    @message = MessageForm.new # formのmodelに入れるオブジェクトを作成
+    @another_entry = @room.entries.partner_of(current_user) # メッセージ相手と部屋の情報を取得
   end
 
   private

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -5,7 +5,7 @@ class PostForm
   include Virtus.model
   extend CarrierWave::Mount
 
-  STATUS_VALUES = [ '受付中', '解決済' ]
+  STATUS_VALUES = [ 'open', 'closed' ]
 
   validates :title,   presence: true, length: { maximum: 50 }
   validates :content, presence: true, length: { maximum: 10000 }

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -8,7 +8,10 @@ class Answer < ApplicationRecord
   def send_notice_to_questioner_or_answerers
     # 自己解決でない場合は質問者に通知を送信
     if self.user_id != self.post.user_id
-      QuestionEntry.create(user_id: self.user_id, post_id: self.post_id) # 回答者用の通知レコードを作成
+      # 初めてコメントする場合は通知レコードを作成
+      if QuestionEntry.find_by(user_id: self.user_id, post_id: self.post_id).blank?
+        QuestionEntry.create(user_id: self.user_id, post_id: self.post_id)
+      end
       questioner = QuestionEntry.find_by(user_id: self.post.user_id, post_id: self.post_id)
       questioner.update(notice: true) if questioner.notice == false
     else # 自己解決した場合は回答者に通知を送信

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -3,4 +3,17 @@ class Answer < ApplicationRecord
   has_many :replies, dependent: :destroy
   belongs_to :user
   belongs_to :post
+
+  # 質問に回答した際の通知処理
+  def send_notice_to_questioner_or_answerers
+    # 自己解決でない場合は質問者に通知を送信
+    if self.user_id != self.post.user_id
+      QuestionEntry.create(user_id: self.user_id, post_id: self.post_id) # 回答者用の通知レコードを作成
+      questioner = QuestionEntry.find_by(user_id: self.post.user_id, post_id: self.post_id)
+      questioner.update(notice: true) if questioner.notice == false
+    else # 自己解決した場合は回答者に通知を送信
+      self.post.send_notice_to_answerers
+    end
+  end
+
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -8,12 +8,8 @@ class Answer < ApplicationRecord
   def send_notice_to_questioner_or_answerers
     # 自己解決でない場合は質問者に通知を送信
     if self.user_id != self.post.user_id
-      # 初めてコメントする場合は通知レコードを作成
-      if QuestionEntry.find_by(user_id: self.user_id, post_id: self.post_id).blank?
-        QuestionEntry.create(user_id: self.user_id, post_id: self.post_id)
-      end
-      questioner = QuestionEntry.find_by(user_id: self.post.user_id, post_id: self.post_id)
-      questioner.update(notice: true) if questioner.notice == false
+      questioner = QuestionEntry.find_or_create_by(user_id: self.post.user_id, post_id: self.post_id)
+      questioner.update(notice: true) unless questioner.notice
     else # 自己解決した場合は回答者に通知を送信
       self.post.send_notice_to_answerers
     end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -27,4 +27,26 @@ class Entry < ApplicationRecord
     sorted_entries
   end
 
+  # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
+  def self.find_or_create_partner(current_user, another_user)
+    current_entries = Entry.where(user_id: current_user)
+    another_entries = Entry.where(user_id: another_user)
+    current_entries.each do |current_entry|
+      another_entries.each do |another_entry|
+        # 共通の部屋を持つ場合
+        if current_entry.room_id == another_entry.room_id
+          # 共通の部屋があることを示す@is_roomをtrueにする
+          @is_room = true
+          @room_id = current_entry.room_id
+          return @is_room, @room_id
+        end
+      end
+    end
+    # 共通の部屋を持たない、もしくはentryを持っていない場合
+    @is_room = nil
+    @room_id = nil
+    @entry = Entry.new
+    return @is_room, @room_id, @entry
+  end
+
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -4,8 +4,7 @@ class Entry < ApplicationRecord
 
   # メッセージ相手と部屋の情報を取得
   def self.another_entries(user)
-    my_room_ids = []
-    my_room_ids << user.entries.map { |entry| entry.room_id }
+    my_room_ids = user.entries.map(&:room_id)
     where(room_id: my_room_ids).where.not(user_id: user)
   end
 
@@ -28,25 +27,17 @@ class Entry < ApplicationRecord
   end
 
   # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
-  def self.find_or_create_partner(current_user, another_user)
-    current_entries = Entry.where(user_id: current_user)
-    another_entries = Entry.where(user_id: another_user)
-    current_entries.each do |current_entry|
-      another_entries.each do |another_entry|
+  def self.find_room_id(user1, user2)
+    entries1 = Entry.where(user_id: user1)
+    entries2 = Entry.where(user_id: user2)
+    entries1.each do |entry1|
+      entries2.each do |entry2|
         # 共通の部屋を持つ場合
-        if current_entry.room_id == another_entry.room_id
-          # 共通の部屋があることを示す@is_roomをtrueにする
-          @is_room = true
-          @room_id = current_entry.room_id
-          return @is_room, @room_id
-        end
+        return @room_id = entry1.room_id if entry1.room_id == entry2.room_id
       end
     end
     # 共通の部屋を持たない、もしくはentryを持っていない場合
-    @is_room = nil
     @room_id = nil
-    @entry = Entry.new
-    return @is_room, @room_id, @entry
   end
 
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,4 +2,11 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
   has_many :pictures, as: :imageable, dependent: :destroy
+
+  # メッセージ相手に通知を送信する処理
+  def send_notice_to_partner
+    partner = Entry.where(room_id: self.room_id).where.not(user_id: self.user_id).first
+    partner.update(notice: true) if partner.notice == false
+  end
+
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,7 @@ class Message < ApplicationRecord
   # メッセージ相手に通知を送信する処理
   def send_notice_to_partner
     partner = Entry.where(room_id: self.room_id).where.not(user_id: self.user_id).first
-    partner.update(notice: true) if partner.notice == false
+    partner.update(notice: true) unless partner&.notice
   end
 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,4 +21,9 @@ class Post < ApplicationRecord
     STATUS[self.status.to_sym]
   end
 
+  # 質問投稿者用の通知レコードを作成
+  def create_entry
+    QuestionEntry.create(user_id: self.user_id, post_id: self.id)
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,4 +34,13 @@ class Post < ApplicationRecord
     end
   end
 
+  # 投稿詳細画面に入ると通知が外れる処理
+  def remove_notice(user)
+    # 通知用レコードがない場合はこの処理をスキップ
+    if QuestionEntry.find_by(user_id: user, post_id: self).present?
+      entry = QuestionEntry.find_by(user_id: user, post_id: self)
+      entry.update(notice: false) if entry.notice == true
+    end
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -43,4 +43,10 @@ class Post < ApplicationRecord
     end
   end
 
+  # 投稿への通知の有無を返す処理
+  def check_notice(user)
+    checked_entry = QuestionEntry.find_by(user_id: user, post_id: self)
+    checked_entry.notice
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,4 +26,12 @@ class Post < ApplicationRecord
     QuestionEntry.create(user_id: self.user_id, post_id: self.id)
   end
 
+  # ベストアンサー決定時に回答者全員に通知を送信する
+  def send_notice_to_answerers
+    answerers = QuestionEntry.where(post_id: self).where.not(user_id: self.user_id)
+    answerers.each do |answerer|
+      answerer.update(notice: true) if answerer.notice == false
+    end
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   has_many :pictures, as: :imageable, dependent: :destroy
   has_many :answers, dependent: :destroy
   has_many :replies, dependent: :destroy
+  has_many :question_entries, dependent: :destroy
   belongs_to :user
   belongs_to :category
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,7 +22,7 @@ class Post < ApplicationRecord
   end
 
   # 質問投稿者用の通知レコードを作成
-  def create_entry
+  def create_notice
     QuestionEntry.create(user_id: self.user_id, post_id: self.id)
   end
 
@@ -30,23 +30,21 @@ class Post < ApplicationRecord
   def send_notice_to_answerers
     answerers = QuestionEntry.where(post_id: self).where.not(user_id: self.user_id)
     answerers.each do |answerer|
-      answerer.update(notice: true) if answerer.notice == false
+      answerer.update(notice: true) unless answerer.notice
     end
   end
 
   # 投稿詳細画面に入ると通知が外れる処理
   def remove_notice(user)
     # 通知用レコードがない場合はこの処理をスキップ
-    if QuestionEntry.find_by(user_id: user, post_id: self).present?
-      entry = QuestionEntry.find_by(user_id: user, post_id: self)
-      entry.update(notice: false) if entry.notice == true
-    end
+    entry = QuestionEntry.find_by(user_id: user, post_id: self)
+    entry.update(notice: false) if entry&.notice
   end
 
   # 投稿への通知の有無を返す処理
   def check_notice(user)
     checked_entry = QuestionEntry.find_by(user_id: user, post_id: self)
-    checked_entry.notice
+    checked_entry&.notice
   end
 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,8 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :category
 
+  STATUS = { open: "受付中", closed: "解決済" }
+
   # 自己解決した場合の処理
   def solved_by_questioner
     best_answer = Answer.find_by(post_id: self, user_id: self.user_id)
@@ -12,4 +14,10 @@ class Post < ApplicationRecord
     self.best_answer_id = best_answer.id
     self.save
   end
+
+  # 英語名で保存された投稿状態(status)を日本語で表示 
+  def translated_status
+    STATUS[self.status.to_sym]
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,7 +8,7 @@ class Post < ApplicationRecord
   # 自己解決した場合の処理
   def solved_by_questioner
     best_answer = Answer.find_by(post_id: self, user_id: self.user_id)
-    self.status = "解決済"
+    self.status = "closed"
     self.best_answer_id = best_answer.id
     self.save
   end

--- a/app/models/question_entry.rb
+++ b/app/models/question_entry.rb
@@ -1,4 +1,12 @@
 class QuestionEntry < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  # 回答、リプライしたエントリーを一覧表示する処理
+  def self.sorted_comment_entries(user)
+    post_ids = user.posts.map { |post| post.id }
+    # 自身の質問に関する情報は除き、新着通知が入った順にソート
+    where(user_id: user).where.not(post_id: post_ids).order(updated_at: :desc)
+  end
+
 end

--- a/app/models/question_entry.rb
+++ b/app/models/question_entry.rb
@@ -1,0 +1,4 @@
+class QuestionEntry < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/question_entry.rb
+++ b/app/models/question_entry.rb
@@ -4,7 +4,7 @@ class QuestionEntry < ApplicationRecord
 
   # 回答、リプライしたエントリーを一覧表示する処理
   def self.sorted_comment_entries(user)
-    post_ids = user.posts.map { |post| post.id }
+    post_ids = user.posts.ids
     # 自身の質問に関する情報は除き、新着通知が入った順にソート
     where(user_id: user).where.not(post_id: post_ids).order(updated_at: :desc)
   end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -3,4 +3,29 @@ class Reply < ApplicationRecord
   belongs_to :user
   belongs_to :post
   belongs_to :answer
+
+  # リプライ時に質問者と回答者に通知を送信する処理
+  def send_notice_to_questioner_and_answerer
+    # 質問者や回答者自身に通知を送信しないよう制限する
+    questioner = QuestionEntry.find_by(user_id: self.post.user_id, post_id: self.post_id)
+    questioner.update(notice: true) if questioner.notice == false && self.user != self.post.user
+    answerer = QuestionEntry.find_by(user_id: self.answer.user_id, post_id: self.post_id)
+    answerer.update(notice: true) if answerer.notice == false && self.user != self.answer.user
+  end
+
+  # 返信者も含めて通知を送信する処理
+  def send_notice_to_commenter
+    # 初めてコメントする場合は通知用レコードを作成
+    if QuestionEntry.find_by(user_id: self.user_id, post_id: self.post_id).blank?
+      QuestionEntry.create(user_id: self.user_id, post_id: self.post_id)
+    end
+    # 回答に紐づく返信者に通知を送信
+    replier_ids = self.answer.replies.map { |reply| reply.user_id }
+    repliers = QuestionEntry.where(user_id: replier_ids, post_id: self.post_id).where.not(user_id: self.user_id)
+    repliers.each do |replier|
+      replier.update(notice: true) if replier.notice == false
+    end
+    self.send_notice_to_questioner_and_answerer # 質問者と回答者に通知を送信
+  end
+
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,4 +1,11 @@
 class Room < ApplicationRecord
   has_many :entries, dependent: :destroy
   has_many :messages, dependent: :destroy
+
+  # メッセージルームに入ると通知が外れる処理
+  def remove_notice(user)
+    entry = Entry.find_by(user_id: user, room_id: self)
+    entry.update(notice: false) if entry.notice == true
+  end
+
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -8,4 +8,10 @@ class Room < ApplicationRecord
     entry.update(notice: false) if entry.notice == true
   end
 
+  # 通知の有無を返す処理
+  def check_notice(user)
+    checked_entry = Entry.find_by(user_id: user, room_id: self)
+    checked_entry.notice
+  end
+
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,13 +5,13 @@ class Room < ApplicationRecord
   # メッセージルームに入ると通知が外れる処理
   def remove_notice(user)
     entry = Entry.find_by(user_id: user, room_id: self)
-    entry.update(notice: false) if entry.notice == true
+    entry.update(notice: false) if entry&.notice
   end
 
   # 通知の有無を返す処理
   def check_notice(user)
     checked_entry = Entry.find_by(user_id: user, room_id: self)
-    checked_entry.notice
+    checked_entry&.notice
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,4 +56,28 @@ class User < ApplicationRecord
     self.picture.present? ? self.picture.url : "default.jpeg"
   end
 
+  # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
+  def find_or_create_room_for(user)
+    current_entries = Entry.where(user_id: self)
+    another_entries = Entry.where(user_id: user.id)
+    current_entries.each do |current_entry|
+      another_entries.each do |another_entry|
+        # 共通の部屋を持つ場合
+        if current_entry.room_id == another_entry.room_id
+          # 共通の部屋があることを示す@is_roomをtrueにする
+          @is_room = true
+          @room_id = current_entry.room_id
+          return @is_room, @room_id
+        end
+      end
+    end
+    # 共通の部屋を持たない場合
+    unless @is_room
+      @is_room = nil
+      @room_id = nil
+      @entry = Entry.new
+      return @is_room, @room_id, @entry
+    end
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :posts
   has_many :answers
   has_many :replies
+  has_many :question_entries
 
   # アカウント認証が済むまでログインできない処理
   def active_for_authentication?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,28 +57,4 @@ class User < ApplicationRecord
     self.picture.present? ? self.picture.url : "default.jpeg"
   end
 
-  # ダイレクトメッセージ用の部屋を相手と共有しているか確認する処理
-  def find_or_create_room_for(user)
-    current_entries = Entry.where(user_id: self)
-    another_entries = Entry.where(user_id: user.id)
-    current_entries.each do |current_entry|
-      another_entries.each do |another_entry|
-        # 共通の部屋を持つ場合
-        if current_entry.room_id == another_entry.room_id
-          # 共通の部屋があることを示す@is_roomをtrueにする
-          @is_room = true
-          @room_id = current_entry.room_id
-          return @is_room, @room_id
-        end
-      end
-    end
-    # 共通の部屋を持たない場合
-    unless @is_room
-      @is_room = nil
-      @room_id = nil
-      @entry = Entry.new
-      return @is_room, @room_id, @entry
-    end
-  end
-
 end

--- a/app/views/questions/answers/index.html.erb
+++ b/app/views/questions/answers/index.html.erb
@@ -11,8 +11,8 @@
         <% else %>
           <p class="notice-icon"></p>
         <% end %>
-        <div><%= image_tag comment_list.user.profile_picture %></div>
-        <div><%= comment_list.user.name %></div>
+        <div><%= image_tag comment_list.post.user.profile_picture %></div>
+        <div><%= comment_list.post.user.name %></div>
         <div><%= comment_list.post.title %></div>
         <% if comment_list.notice == true %>
           <p>新着のメッセージがあります</p>

--- a/app/views/questions/answers/index.html.erb
+++ b/app/views/questions/answers/index.html.erb
@@ -1,0 +1,18 @@
+<% provide(:title, "あなたの回答") %>
+
+<% if @comment_lists.blank? %>
+  <p>まだ質問に回答していません</p>
+<% else %>
+  <% @comment_lists.each do |comment_list| %>
+    <%= link_to(questions_post_path(comment_list.post)) do %>
+      <div>
+        <div><%= image_tag comment_list.user.profile_picture %></div>
+        <div><%= comment_list.user.name %></div>
+        <div><%= comment_list.post.title %></div>
+        <% if comment_list.notice == true %>
+          <p>新着のメッセージがあります</p>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/questions/answers/index.html.erb
+++ b/app/views/questions/answers/index.html.erb
@@ -6,6 +6,11 @@
   <% @comment_lists.each do |comment_list| %>
     <%= link_to(questions_post_path(comment_list.post)) do %>
       <div>
+        <% if comment_list.post.check_notice(current_user) == true %>
+          <p class="notice-icon has-notice"></p>
+        <% else %>
+          <p class="notice-icon"></p>
+        <% end %>
         <div><%= image_tag comment_list.user.profile_picture %></div>
         <div><%= comment_list.user.name %></div>
         <div><%= comment_list.post.title %></div>

--- a/app/views/questions/posts/show.html.erb
+++ b/app/views/questions/posts/show.html.erb
@@ -12,7 +12,7 @@
       <p><%= @post.user.name %></p>
     </div>
     <div class="post-contents-category"><%= @post.category.name %></div>
-    <div class="post-contents-status"><%= @post.status %></div>
+    <div class="post-contents-status"><%= @post.translated_status %></div>
     <div class="post-contents-title"><%= @post.title %></div>
     <div class="post-contents-content"><%= @post.content %></div>
     <div class="post-contents-pictures">

--- a/app/views/questions/shared/_best_answer_form.html.erb
+++ b/app/views/questions/shared/_best_answer_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: post, url: url, method: method, local: true do |f| %>
 
   <%= f.hidden_field :best_answer_id, value: answer.id %>
-  <%= f.hidden_field :status, value: "解決済" %>
+  <%= f.hidden_field :status, value: "closed" %>
 
   <div class="action">
     <%= button_tag type: "submit", data: { confirm: "この回答をベストアンサーにします。修正はできませんがよろしいですか？" } do %>

--- a/app/views/questions/shared/_post_form.html.erb
+++ b/app/views/questions/shared/_post_form.html.erb
@@ -12,10 +12,10 @@
   <% if params[:id].present? %>
     <div class="field">
       <%= f.label :status %>
-      <%= f.select :status, { 受付中: "受付中", 解決済: "解決済" } %>
+      <%= f.select :status, { open: "受付中", closed: "解決済" }.invert %>
     </div>
   <% else %>
-    <%= f.hidden_field :status, value: "受付中" %>
+    <%= f.hidden_field :status, value: "open" %>
   <% end %>
 
   <div class="filed">

--- a/app/views/questions/shared/answers/_answer_list.html.erb
+++ b/app/views/questions/shared/answers/_answer_list.html.erb
@@ -37,7 +37,7 @@
         <% answer.replies&.order(created_at: :asc).each do |reply| %>
           <div id="reply-contents-<%= reply.id %>">
             <div class="reply-username">
-              <%= reply.user.profile_picture %>
+              <%= image_tag reply.user.profile_picture %>
               <p><%= reply.user.name %></p>
             </div>
             <div class="reply-createdat"><%= l reply.created_at, format: :year %></div>

--- a/app/views/questions/shared/replies/_reply_list.html.erb
+++ b/app/views/questions/shared/replies/_reply_list.html.erb
@@ -3,7 +3,7 @@
   <% answer.replies&.order(created_at: :asc).each do |reply| %>
     <div id="reply-contents-<%= reply.id %>">
       <div class="reply-username">
-        <%= reply.user.profile_picture %>
+        <%= image_tag reply.user.profile_picture %>
         <p><%= reply.user.name %></p>
       </div>
       <div class="reply-createdat"><%= l reply.created_at, format: :year %></div>

--- a/app/views/users/basics/show.html.erb
+++ b/app/views/users/basics/show.html.erb
@@ -56,7 +56,12 @@
   <h4>投稿した質問</h4>
   <% @posts.each do |post| %>
     <%= link_to(questions_post_path(post)) do %>
-      <%= post.title %>
+      <% if post.check_notice(current_user) == true %>
+        <p class="notice-icon has-notice"></p>
+      <% else %>
+        <p class="notice-icon"></p>
+      <% end %>      
+      <p><%= post.title %></p>
     <% end %>
   <% end %>
 

--- a/app/views/users/basics/show.html.erb
+++ b/app/views/users/basics/show.html.erb
@@ -41,7 +41,7 @@
   </div>
 
   <% unless current_user == @user %>
-    <% if @is_room == true %>
+    <% if @room_id.present? %>
       <%= link_to "メッセージ", users_room_path(@room_id) %>
     <% else %>
       <%= form_with model: @entry.room, url: users_rooms_path, method: :post, local: true do |f| %>

--- a/app/views/users/rooms/index.html.erb
+++ b/app/views/users/rooms/index.html.erb
@@ -12,15 +12,16 @@
       <li>
         <%= link_to(users_basic_path(entry.user)) do %>
           <div class="room-list__image">
-            <% if entry.user.picture? %>
-              <%= image_tag entry.user.picture.url %>
-            <% else %>
-              <%= image_tag 'default.jpeg' %>
-            <% end %>
+            <%= image_tag entry.user.profile_picture %>
           </div>
         <% end %>
         <%= link_to(users_room_path(entry.room)) do %>
           <div class="room-list__text">
+            <% if entry.room.check_notice(current_user) == true %>
+              <p class="notice-icon has-notice"></p>
+            <% else %>
+              <p class="notice-icon"></p>
+            <% end %>
             <p><%= entry.user.name %></p>
             <%# 最後にメッセージした時間を表示 %>
             <% if entry.room.messages.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
         get 'get_children_categories' # 質問の投稿・編集画面用
       end
     end
-    resources :answers, only: [:create, :update]
+    resources :answers, only: [:index, :create, :update]
     resources :replies, only: [:create, :update]
     resources :categories, only: [:show]
   end

--- a/db/migrate/20200902205542_create_entries.rb
+++ b/db/migrate/20200902205542_create_entries.rb
@@ -3,6 +3,7 @@ class CreateEntries < ActiveRecord::Migration[6.0]
     create_table :entries do |t|
       t.references :user, null: false, foreign_key: true
       t.references :room, null: false, foreign_key: true
+      t.boolean :notice, null: false, default: false
 
       t.timestamps
     end

--- a/db/migrate/20201209120026_create_posts.rb
+++ b/db/migrate/20201209120026_create_posts.rb
@@ -3,7 +3,7 @@ class CreatePosts < ActiveRecord::Migration[6.0]
     create_table :posts do |t|
       t.string :title, null: false
       t.text :content, null: false
-      t.string :status, default: "受付中", null: false
+      t.string :status, default: "open", null: false
       t.integer :best_answer_id
 
       t.references :user, null: false, foreign_key: true

--- a/db/migrate/20210208130131_create_question_entries.rb
+++ b/db/migrate/20210208130131_create_question_entries.rb
@@ -1,0 +1,11 @@
+class CreateQuestionEntries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :question_entries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.boolean :notice, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2021_01_31_140900) do
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.text "content", null: false
-    t.string "status", default: "受付中", null: false
+    t.string "status", default: "open", null: false
     t.integer "best_answer_id"
     t.bigint "user_id", null: false
     t.bigint "category_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_31_140900) do
+ActiveRecord::Schema.define(version: 2021_02_08_130131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,16 @@ ActiveRecord::Schema.define(version: 2021_01_31_140900) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "question_entries", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.boolean "notice", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_question_entries_on_post_id"
+    t.index ["user_id"], name: "index_question_entries_on_user_id"
+  end
+
   create_table "replies", force: :cascade do |t|
     t.string "body"
     t.bigint "user_id", null: false
@@ -156,6 +166,8 @@ ActiveRecord::Schema.define(version: 2021_01_31_140900) do
   add_foreign_key "posts", "categories"
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"
+  add_foreign_key "question_entries", "posts"
+  add_foreign_key "question_entries", "users"
   add_foreign_key "replies", "answers"
   add_foreign_key "replies", "posts"
   add_foreign_key "replies", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2021_02_08_130131) do
   create_table "entries", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "room_id", null: false
+    t.boolean "notice", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["room_id"], name: "index_entries_on_room_id"

--- a/db/seeds/comment.rb
+++ b/db/seeds/comment.rb
@@ -1,4 +1,5 @@
 post = Post.create(title: "test", content: "test", user_id: 1, category_id: 50)
+post_entry = QuestionEntry.create(user_id: 1, post_id: post.id)
 
 answers = []
 3.times do |n|
@@ -7,6 +8,12 @@ answers = []
                         post_id: post.id)
 end
 Answer.import answers
+
+answer_entries = []
+2.times do |n|
+  answer_entries << QuestionEntry.new(user_id: n+2, post_id: post.id)
+end
+QuestionEntry.import answer_entries
 
 replies = []
 3.times do |n|

--- a/spec/controllers/questions/answers_controller_spec.rb
+++ b/spec/controllers/questions/answers_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Questions::AnswersController, type: :controller do
         post :create, xhr: true, params: { answer_form: { post_id: my_post, body: answer_form.body } }
         end.to change(Answer, :count).by(1)
         # 質問の状態を「解決済」にし、best_answer_idに回答のidを追加しているか検証
-        expect(my_post.reload.status).to eq "解決済"
+        expect(my_post.reload.status).to eq "closed"
         best_answer = Answer.find_by(post_id: my_post, user_id: user)
         expect(my_post.reload.best_answer_id).to eq best_answer.id
         expect(response).to have_http_status "200"
@@ -78,7 +78,7 @@ RSpec.describe Questions::AnswersController, type: :controller do
         post :create, params: { answer_form: { post_id: my_post, body: answer_form.body } }
         end.to change(Answer, :count).by(1)
         # 質問の状態を「解決済」にし、best_answer_idに回答のidを追加しているか検証
-        expect(my_post.reload.status).to eq "解決済"
+        expect(my_post.reload.status).to eq "closed"
         best_answer = Answer.find_by(post_id: my_post, user_id: user)
         expect(my_post.reload.best_answer_id).to eq best_answer.id
         expect(response).to have_http_status "302"

--- a/spec/controllers/questions/answers_controller_spec.rb
+++ b/spec/controllers/questions/answers_controller_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Questions::AnswersController, type: :controller do
   let!(:my_post) { create(:post, user_id: user.id, category_id: children_category.id) }
   let!(:another_post) { create(:post, user_id: another_user.id, category_id: children_category.id) }
 
+  # indexアクションに関するテスト
+  describe "indexアクション" do
+    it "正常なレスポンスとテンプレートを返す" do
+      login_user(user)
+      get :index
+      expect(response).to have_http_status "200"
+      expect(response).to render_template :index
+    end
+  end
+
   # createアクションに関するテスト
   describe '非同期通信によるcreateアクション' do
     context "フォーム入力が無効であった場合" do

--- a/spec/controllers/questions/answers_controller_spec.rb
+++ b/spec/controllers/questions/answers_controller_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe Questions::AnswersController, type: :controller do
         expect(response).to render_template "questions/answers/errors"
       end
     end
+    context "他人の回答を編集しようとした場合" do
+      let!(:another_answer) { create(:answer, user_id: another_user.id, post_id: another_post.id) }
+      it "回答の編集に失敗し、ユーザー詳細画面にリダイレクトする" do
+        login_user(user)
+        patch :update, xhr: true, params: { id: another_answer.id, answer_form: { id: another_answer.id,
+                                                                                  post_id: another_post.id,
+                                                                                  body: "edited_answer" } }
+        expect(response).to have_http_status "200"
+        expect(response).to redirect_to users_basic_path(user)
+      end
+    end
     context "フォーム入力が有効であった場合" do
       it "回答の編集に成功する" do
         login_user(user)
@@ -139,6 +150,17 @@ RSpec.describe Questions::AnswersController, type: :controller do
         expect(answer.reload.body).to eq "answer"
         expect(response).to have_http_status "200"
         expect(response).to render_template "questions/posts/show"
+      end
+    end
+    context "他人の回答を編集しようとした場合" do
+      let!(:another_answer) { create(:answer, user_id: another_user.id, post_id: another_post.id) }
+      it "回答の編集に失敗し、ユーザー詳細画面にリダイレクトする" do
+        login_user(user)
+        patch :update, params: { id: another_answer.id, answer_form: { id: another_answer.id,
+                                                                       post_id: another_post.id,
+                                                                       body: "edited_answer" } }
+        expect(response).to have_http_status "302"
+        expect(response).to redirect_to users_basic_path(user)
       end
     end
     context "フォーム入力が有効であった場合" do

--- a/spec/controllers/questions/answers_controller_spec.rb
+++ b/spec/controllers/questions/answers_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Questions::AnswersController, type: :controller do
     end
     context "フォーム入力が有効であった場合" do
       let(:answer_form) { build(:answer_form) }
+      let!(:questioner) { create(:question_entry, user_id: another_user.id, post_id: another_post.id) }
       it "回答の作成に成功する" do
         login_user(user)
         expect do
@@ -61,6 +62,7 @@ RSpec.describe Questions::AnswersController, type: :controller do
     end
     context "フォーム入力が有効であった場合" do
       let(:answer_form) { build(:answer_form) }
+      let!(:questioner) { create(:question_entry, user_id: another_user.id, post_id: another_post.id) }
       it "回答の作成に成功する" do
         login_user(user)
         expect do

--- a/spec/controllers/questions/categories_controller_spec.rb
+++ b/spec/controllers/questions/categories_controller_spec.rb
@@ -7,12 +7,22 @@ RSpec.describe Questions::CategoriesController, type: :controller do
   let!(:posts) { 3.times.collect { |i| create(:post, category_id: children_category.id, user_id: user.id) } }
 
   describe 'showアクション' do
-    it "カテゴリーごとの質問一覧画面を表示する" do
-      login_user(user)
-      get :show, params: { id: children_category.id }
-      expect(response).to have_http_status "200"
-      expect(response).to render_template :show
-      expect(assigns(:posts)).to eq posts.reverse
+    context "DBに存在するカテゴリーidを入力した場合" do
+      it "カテゴリーごとの質問一覧画面を表示する" do
+        login_user(user)
+        get :show, params: { id: children_category.id }
+        expect(response).to have_http_status "200"
+        expect(response).to render_template :show
+        expect(assigns(:posts)).to eq posts.reverse
+      end
+    end
+    context "DBに存在しないカテゴリーidを入力した場合" do
+      it "rootにリダイレクトする" do
+        login_user(user)
+        get :show, params: { id: 10000000 }
+        expect(response).to have_http_status "302"
+        expect(response).to redirect_to root_path
+      end
     end
   end
 

--- a/spec/controllers/questions/posts_controller_spec.rb
+++ b/spec/controllers/questions/posts_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Questions::PostsController, type: :controller do
         expect{ post :create, params: { post_form: { category_id: children_category.id,
                                                      title: post_form.title,
                                                      content: post_form.content,
-                                                     status: "受付中" } } }.to change(Post, :count).by(1)
+                                                     status: "open" } } }.to change(Post, :count).by(1)
         expect(response).to have_http_status "302"
         expect(response).to redirect_to users_basic_path(user)
       end
@@ -98,7 +98,7 @@ RSpec.describe Questions::PostsController, type: :controller do
         patch :update, params: { id: another_post.id, post_form: { category_id: children_category.id,
                                                                    title: "title",
                                                                    content: "content",
-                                                                   status: "解決済"} }
+                                                                   status: "closed"} }
         expect(response).to have_http_status "302"
         expect(response).to redirect_to users_basic_path(user)
       end
@@ -109,7 +109,7 @@ RSpec.describe Questions::PostsController, type: :controller do
         patch :update, params: { id: post.id, post_form: { category_id: children_category.id,
                                                            title: "title",
                                                            content: "content",
-                                                           status: "解決済"} }
+                                                           status: "closed"} }
         expect(response).to have_http_status "302"
         expect(response).to redirect_to questions_post_path(post)
       end
@@ -133,10 +133,10 @@ RSpec.describe Questions::PostsController, type: :controller do
     let(:answer) { create(:answer, user_id: another_user.id, post_id: post.id)}
     it "ベストアンサーを選出しshow画面にリダイレクトする" do
       login_user(user)
-      patch :select_best_answer, params: { id: post.id, post_form: { status: "解決済", best_answer_id: answer.id } }
+      patch :select_best_answer, params: { id: post.id, post_form: { status: "closed", best_answer_id: answer.id } }
       expect(response).to have_http_status "302"
       expect(response).to redirect_to questions_post_path(post)
-      expect(post.reload.status).to eq "解決済"
+      expect(post.reload.status).to eq "closed"
       expect(post.reload.best_answer_id).to eq answer.id
     end
   end

--- a/spec/controllers/questions/replies_controller_spec.rb
+++ b/spec/controllers/questions/replies_controller_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe Questions::RepliesController, type: :controller do
         expect(response).to render_template "questions/replies/update_errors"
       end
     end
+    context "他人のリプライを編集しようとした場合" do
+      let(:another_user) { create(:another_user) }
+      let!(:another_reply) { create(:reply, user_id: another_user.id, answer_id: answer.id, post_id: test_post.id) }
+      it "リプライの編集に失敗し、ユーザー詳細画面にリダイレクトする" do
+        login_user(user)
+        patch :update, xhr: true, params: { id: another_reply.id, reply_form: { id: another_reply.id,
+                                                                                answer_id: answer.id,
+                                                                                post_id: test_post.id,
+                                                                                body: "editied_reply" } }
+        expect(response).to have_http_status "200"
+        expect(response).to redirect_to users_basic_path(user)
+      end
+    end
     context "フォーム入力が有効であった場合" do
       it "リプライの編集に成功する" do
         login_user(user)
@@ -107,6 +120,19 @@ RSpec.describe Questions::RepliesController, type: :controller do
         expect(reply.reload.body).to eq "reply"
         expect(response).to have_http_status "200"
         expect(response).to render_template "questions/posts/show"
+      end
+    end
+    context "他人のリプライを編集しようとした場合" do
+      let(:another_user) { create(:another_user) }
+      let!(:another_reply) { create(:reply, user_id: another_user.id, answer_id: answer.id, post_id: test_post.id) }
+      it "リプライの編集に失敗し、ユーザー詳細画面にリダイレクトする" do
+        login_user(user)
+        patch :update, params: { id: another_reply.id, reply_form: { id: another_reply.id,
+                                                                     answer_id: answer.id,
+                                                                     post_id: test_post.id,
+                                                                     body: "editied_reply" } }
+        expect(response).to have_http_status "302"
+        expect(response).to redirect_to users_basic_path(user)
       end
     end
     context "フォーム入力が有効であった場合" do

--- a/spec/controllers/users/basics_controller_spec.rb
+++ b/spec/controllers/users/basics_controller_spec.rb
@@ -19,15 +19,15 @@ RSpec.describe Users::BasicsController, type: :controller do
         login_user(user)
         get :show, params: { id: another_user }
         expect(assigns(:posts)).to eq posts.reverse
-        # 共通のメッセージルームがないので@is_roomがnilを返す
-        expect(assigns(:is_room)).to eq nil
+        # 共通のメッセージルームがないので@room_idがnilを返す
+        expect(assigns(:room_id)).to eq nil
         expect(response).to have_http_status "200"
         expect(response).to render_template :show
       end
     end
     context "相手が共通のメッセージルームを持つユーザーの場合" do
+      let(:room) { create(:room) }
       before do
-        room = create(:room)
         create(:entry, user_id: user.id, room_id: room.id)
         create(:entry, user_id: another_user.id, room_id: room.id)
       end
@@ -35,10 +35,18 @@ RSpec.describe Users::BasicsController, type: :controller do
         login_user(user)
         get :show, params: { id: another_user }
         expect(assigns(:posts)).to eq posts.reverse
-        # 共通のメッセージルームがあるので@is_roomがtrueを返す
-        expect(assigns(:is_room)).to eq true
+        # 共通のメッセージルームがあるので@room_idが部屋番号を返す
+        expect(assigns(:room_id)).to eq room.id
         expect(response).to have_http_status "200"
         expect(response).to render_template :show
+      end
+    end
+    context "DBに存在しないユーザーの詳細画面に入ろうとした場合" do
+      it "rootにリダイレクトする" do
+        login_user(user)
+        get :show, params: { id: 1000000 }
+        expect(response).to have_http_status "302"
+        expect(response).to redirect_to root_path
       end
     end
     context "退会済みのユーザー詳細画面に入ろうとした場合" do

--- a/spec/controllers/users/messages_controller_spec.rb
+++ b/spec/controllers/users/messages_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Users::MessagesController, type: :controller do
         message = Message.create(user_id: another_user.id, room_id: room.id, body: "MyText")
         expect { delete :destroy, params: { id: message.id } }.not_to change(Message, :count)
         expect(response).to have_http_status "302"
+        expect(response).to redirect_to users_basic_path(user)
       end
     end
   end

--- a/spec/controllers/users/messages_controller_spec.rb
+++ b/spec/controllers/users/messages_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Users::MessagesController, type: :controller do
   let(:room) { create(:room) }
   let!(:parent_category) { create(:parent_category) }
   let!(:children_category) { create(:children_category, ancestry: parent_category.id) }
+  let!(:another_entry) { create(:entry, user_id: another_user.id, room_id: room.id) }
     
   describe "createアクション" do
     context "メッセージ文も画像も空だった場合" do

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :post, class: Post do
     title { "MyString" }
     content { "MyString" }
-    status { "受付中" }
+    status { "open" }
   end
 
   factory :post_form, class: PostForm do

--- a/spec/factories/question_entries.rb
+++ b/spec/factories/question_entries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :question_entry do
+    user { nil }
+    post { nil }
+    notice { false }
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Answer, type: :model do
+  let(:answerer1) { create(:user) }
+  let(:answerer2) { create(:guest_user) }
+  let(:questioner) { create(:another_user) }
+  let!(:parent_category) { create(:parent_category) }
+  let!(:children_category) { create(:children_category, ancestry: parent_category.id) }
+  let!(:post) { create(:post, user_id: questioner.id, category_id: children_category.id) }
+
+  # 回答者が質問者に通知を送信する処理
+  describe "send_notice_to_questioner_or_answerersメソッド" do
+    context "自己解決でない場合" do
+      it "質問者の通知カラムがtrueを返す" do
+        create(:question_entry, user_id: questioner.id, post_id: post.id) # 質問者の通知レコードを作成
+        answer = create(:answer, user_id: answerer1.id, post_id: post.id) # 質問者以外の人が回答を作成
+        answer.send_notice_to_questioner_or_answerers
+        question_entry = QuestionEntry.find_by(user_id: questioner, post_id: post)
+        expect(question_entry.notice).to eq true
+      end
+    end
+    context "自己解決の場合" do
+      it "回答者の通知カラムがtrueを返す" do
+        answer_entry1 = create(:question_entry, user_id: answerer1.id, post_id: post.id) # 回答者の通知レコードを作成
+        answer_entry2 = create(:question_entry, user_id: answerer2.id, post_id: post.id)
+        answer = create(:answer, user_id: questioner.id, post_id: post.id) # 質問者が回答を作成
+        answer.send_notice_to_questioner_or_answerers
+        expect(answer_entry1.reload.notice).to eq true
+        expect(answer_entry2.reload.notice).to eq true
+      end
+    end
+  end
+
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -77,25 +77,20 @@ RSpec.describe Entry, type: :model do
     end
   end
 
-  describe "self.find_or_create_partnerメソッド" do
+  describe "self.find_room_idメソッド" do
     let(:room) { create(:room) }
     context "共通の部屋を持つ場合" do
-      it "@is_roomはture, @room_idは部屋番号を返す" do
+      it "room_idを返す" do
         current_entry = create(:entry, user_id: user.id, room_id: room.id)
         another_entry = create(:entry, user_id: another_user.id, room_id: room.id)
-        # arrayは@is_room, @room_id, @entryの配列
-        array = Entry.find_or_create_partner(user, another_user)
-        expect(array[0]).to eq true
-        expect(array[1]).to eq current_entry.room_id
-        expect(array[2]).not_to be_present
+        room_id = Entry.find_room_id(user, another_user)
+        expect(room_id).to eq current_entry.room_id
       end
     end
     context "共通の部屋を持たない場合" do
-      it "@entryを生成して返す" do
-        array = Entry.find_or_create_partner(user, another_user)
-        expect(array[0]).to eq nil
-        expect(array[1]).to eq nil
-        expect(array[2]).to be_present
+      it "nilを返す" do
+        room_id = Entry.find_room_id(user, another_user)
+        expect(room_id).to eq nil
       end
     end
   end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -77,4 +77,27 @@ RSpec.describe Entry, type: :model do
     end
   end
 
+  describe "self.find_or_create_partnerメソッド" do
+    let(:room) { create(:room) }
+    context "共通の部屋を持つ場合" do
+      it "@is_roomはture, @room_idは部屋番号を返す" do
+        current_entry = create(:entry, user_id: user.id, room_id: room.id)
+        another_entry = create(:entry, user_id: another_user.id, room_id: room.id)
+        # arrayは@is_room, @room_id, @entryの配列
+        array = Entry.find_or_create_partner(user, another_user)
+        expect(array[0]).to eq true
+        expect(array[1]).to eq current_entry.room_id
+        expect(array[2]).not_to be_present
+      end
+    end
+    context "共通の部屋を持たない場合" do
+      it "@entryを生成して返す" do
+        array = Entry.find_or_create_partner(user, another_user)
+        expect(array[0]).to eq nil
+        expect(array[1]).to eq nil
+        expect(array[2]).to be_present
+      end
+    end
+  end
+
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  let(:user) { create(:user) }
+  let(:partner) { create(:another_user) }
+
+  let!(:parent_category) { create(:parent_category) }
+  let!(:children_category) { create(:children_category, ancestry: parent_category.id) }
+
+  # メッセージ相手が通知を受信するためのエントリーを作成
+  let(:room) { create(:room) }
+  let!(:partner_entry) { create(:entry, user_id: partner.id, room_id: room.id) }
+
+  describe "send_notice_to_partnerメソッド" do
+    it "メッセージ相手に通知を送信する" do
+      message = create(:message, user_id: user.id, room_id: room.id)
+      message.send_notice_to_partner
+      expect(partner_entry.reload.notice).to eq true
+    end
+  end
+
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -32,4 +32,19 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  # ベストアンサー決定時に回答者全員に通知を送信する
+  describe "send_notice_to_answerers" do
+    let(:user1) { create(:another_user) }
+    let(:user2) { create(:guest_user) }
+    let!(:questioner) { create(:question_entry, user_id: user.id, post_id: post.id) } 
+    let!(:answerer1) { create(:question_entry, user_id: user1.id, post_id: post.id) }
+    let!(:answerer2) { create(:question_entry, user_id: user2.id, post_id: post.id) }
+    it "回答者の通知カラムがtrueを返す" do
+      post.send_notice_to_answerers
+      expect(questioner.reload.notice).to eq false # 質問者には通知が送信されない
+      expect(answerer1.reload.notice).to eq true
+      expect(answerer2.reload.notice).to eq true
+    end
+  end
+
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  let(:user) { create(:user) }
+  let!(:parent_category) { create(:parent_category) }
+  let!(:children_category) { create(:children_category, ancestry: parent_category.id) }
+  let!(:post) { create(:post, user_id: user.id, category_id: children_category.id) }
+  let!(:answer_by_questioner) { create(:answer, user_id: user.id, post_id: post.id) }
+
+  # 自己解決した場合の処理
+  describe "solved_by_questionerメソッド" do
+    it "投稿の受付状態を「closed」に変更し、ベストアンサーを決定する" do
+      post.solved_by_questioner
+      expect(post.reload.status).to eq "closed"
+      expect(post.reload.best_answer_id).to eq answer_by_questioner.id
+    end
+  end
+
+  # 英語名で保存された投稿状態(status)を日本語で表示 
+  describe "translated_statusメソッド" do
+    it "デフォルトの受付状態である「受付中」を表示する" do
+      expect(post.translated_status).to eq "受付中"
+    end
+  end
+
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -47,4 +47,13 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  # 投稿詳細画面に入ると通知が外れる処理
+  describe "remove_noticeメソッド" do
+    let!(:entry) { create(:question_entry, user_id: user.id, post_id: post.id, notice: true) }
+    it "通知カラムがfalseを返す" do
+      post.remove_notice(user)
+      expect(entry.reload.notice).to eq false
+    end
+  end
+
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Post, type: :model do
   end
 
   # 質問投稿者用に通知レコードを作成
-  describe "create_entryメソッド" do
+  describe "create_noticeメソッド" do
     it "質問とユーザーを紐づけたリストを作成し、通知カラムがfalseになっている" do
-      post.create_entry
+      post.create_notice
       question_entry = QuestionEntry.find_by(user_id: post.user_id, post_id: post)
       expect(question_entry.notice).to eq false
     end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -56,4 +56,13 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  # 自分が投稿した質問、もしくは回答した質問に通知が来ているか確認する処理
+  describe "check_noticeメソッド" do
+    let!(:entry) { create(:question_entry, user_id: user.id, post_id: post.id, notice: true) }
+    it "通知があるのでnoticeカラムがtrueを返す" do
+      post.check_notice(user)
+      expect(entry.reload.notice).to eq true
+    end
+  end
+
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  # 質問投稿者用に通知レコードを作成
+  describe "create_entryメソッド" do
+    it "質問とユーザーを紐づけたリストを作成し、通知カラムがfalseになっている" do
+      post.create_entry
+      question_entry = QuestionEntry.find_by(user_id: post.user_id, post_id: post)
+      expect(question_entry.notice).to eq false
+    end
+  end
+
 end

--- a/spec/models/question_entry.rb
+++ b/spec/models/question_entry.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe QuestionEntry, type: :model do
+
+  before do
+    @user1 = create(:user)
+    @user2 = create(:another_user)
+    @user3 = create(:guest_user)
+
+    parent_category = create(:parent_category)
+    children_category = create(:children_category, ancestry: parent_category.id)
+    
+    # post1にはuser3が作成した回答が1つ含まれる
+    post1 = create(:post, user_id: @user1.id, category_id: children_category.id)
+    answer1 = create(:answer, user_id: @user3.id, post_id: post1.id)
+    @entry1 = create(:question_entry, user_id: @user3.id, post_id: post1.id, updated_at: Time.now + 1.second)
+
+    # post2にはuser3が作成したリプライが1つ含まれる
+    post2 = create(:post, user_id: @user2.id, category_id: children_category.id)
+    answer2 = create(:answer, user_id: @user2.id, post_id: post2.id)
+    reply2 = create(:reply, user_id: @user3.id, post_id: post2.id, answer_id: answer2.id)
+    @entry2 = create(:question_entry, user_id: @user3.id, post_id: post2.id)
+
+    # post3はuser3が作成
+    post3 = create(:post, user_id: @user3.id, category_id: children_category.id)
+    @entry3 = create(:question_entry, user_id: @user3.id, post_id: post3.id)
+  end
+
+  describe "self.sorted_comment_entriesメソッド" do
+    it "@user3が回答、リプライしたエントリーを一覧表示する" do
+      comment_lists = QuestionEntry.sorted_comment_entries(@user3)
+      expect(comment_lists).to eq [@entry1, @entry2] # post3はuser3が作成した質問なので@entry3は一覧に加えない
+    end
+  end
+
+end

--- a/spec/models/reply_spec.rb
+++ b/spec/models/reply_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Reply, type: :model do
+  let(:user1) { create(:user) }
+  let(:user2) { create(:another_user) }
+  let(:user3) { create(:guest_user) }
+  let!(:parent_category) { create(:parent_category) }
+  let!(:children_category) { create(:children_category, ancestry: parent_category.id) }
+  let!(:post) { create(:post, user_id: user3.id, category_id: children_category.id) }
+  let!(:questioner) { create(:question_entry, user_id: user3.id, post_id: post.id) } # 質問者用の通知レコード
+
+  describe "send_notice_to_questioner_and_answererメソッド" do
+    context "リプライした人が質問投稿者であった場合" do
+      it "回答者にのみ通知を送信する" do
+        answer = create(:answer, user_id: user1.id, post_id: post.id) # user1が回答を作成
+        answerer = create(:question_entry, user_id: user1.id, post_id: post.id) # 回答者の通知レコードを作成
+        reply = create(:reply, user_id: user3.id, post_id: post.id, answer_id: answer.id) # 返信者は質問者と同じuser3
+        reply.send_notice_to_questioner_and_answerer
+        expect(questioner.reload.notice).to eq false
+        expect(answerer.reload.notice).to eq true
+      end
+    end
+    context "リプライした人が回答者であった場合" do
+      it "質問者投稿者にのみ通知を送信する" do
+        answer = create(:answer, user_id: user1.id, post_id: post.id) # user1が回答を作成
+        answerer = create(:question_entry, user_id: user1.id, post_id: post.id) # 回答者の通知レコードを作成
+        reply = create(:reply, user_id: user1.id, post_id: post.id, answer_id: answer.id) # 返信者は回答者と同じuser1
+        reply.send_notice_to_questioner_and_answerer
+        expect(questioner.reload.notice).to eq true
+        expect(answerer.reload.notice).to eq false
+      end
+    end
+    context "リプライした人が質問投稿者でも回答者でもない場合" do
+      it "質問投稿者と回答者の両方に通知を送信する" do
+        answer = create(:answer, user_id: user1.id, post_id: post.id) # user1が回答を作成
+        answerer = create(:question_entry, user_id: user1.id, post_id: post.id) # 回答者の通知レコードを作成
+        reply = create(:reply, user_id: user2.id, post_id: post.id, answer_id: answer.id) # 返信者は質問者でも回答者でもないuser2
+        reply.send_notice_to_questioner_and_answerer
+        expect(questioner.reload.notice).to eq true
+        expect(answerer.reload.notice).to eq true
+      end
+    end
+  end
+
+  describe "send_notice_to_commenterメソッド" do
+    it "回答に紐づく返信者に通知を送信する" do
+      answer = create(:answer, user_id: user1.id, post_id: post.id) # user1が回答を作成
+      answerer = create(:question_entry, user_id: user1.id, post_id: post.id) # 回答者の通知レコードを作成
+      reply1 = create(:reply, user_id: user1.id, post_id: post.id, answer_id: answer.id)
+      reply2 = create(:reply, user_id: user2.id, post_id: post.id, answer_id: answer.id)
+      replier = create(:question_entry, user_id: user2.id, post_id: post.id) # 返信者用の通知レコードを作成
+      reply3 = create(:reply, user_id: user3.id, post_id: post.id, answer_id: answer.id)
+      reply3.send_notice_to_commenter # user3が返信した場合
+      # 他の返信者(user1,user2)に通知が送信される
+      expect(replier.reload.notice).to eq true # user2に通知を送信する
+      expect(questioner.reload.notice).to eq false # 返信者(user3)は質問者と同じなので通知は送信されない
+      expect(answerer.reload.notice).to eq true # 回答者(user1)は返信者と異なるので通知が送信される
+    end
+  end
+
+end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -12,4 +12,11 @@ RSpec.describe Room, type: :model do
     end
   end
 
+  describe "check_noticeメソッド" do
+    it "通知があるのでnoticeカラムがtrueを返す" do
+      room.check_notice(user)
+      expect(current_entry.reload.notice).to eq true
+    end
+  end
+
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Room, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:room) { create(:room) }
+  let!(:current_entry) { create(:entry, user_id: user.id, room_id: room.id, notice: true) }
+
+  describe "remove_noticeメソッド" do
+    it "noticeカラムがfalseを返す" do
+      room.remove_notice(user)
+      expect(current_entry.reload.notice).to eq false
+    end
+  end
+
 end


### PR DESCRIPTION
### 追加した機能
・DMと質問掲示板に通知機能を追加しました。
・DMでは、メッセージを送信した際に相手に通知が飛び、メッセージルームに入ると通知が外れます。
・質問掲示板では、質問者と回答者、リプライヤーに通知が飛び、質問画面に入ると通知が外れます。

### 細かな変更点
・投稿の受付状態(status)を英語表記で保存する仕様に変更しました。
・DMの一覧で、メッセージ相手をソートするメソッドをUser -> Entryに移しました。